### PR TITLE
42 - uses demo from lecture to change this Dockerfile, installs libra…

### DIFF
--- a/paperless/src/Paperless.OcrWorker/Dockerfile
+++ b/paperless/src/Paperless.OcrWorker/Dockerfile
@@ -1,17 +1,41 @@
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+# ───────────────────────────────
+# BASE IMAGE (Debian Bookworm)
+# ───────────────────────────────
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-bookworm-slim AS base
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ghostscript \
+       libleptonica-dev \
+       libtesseract-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV TESSDATA_PREFIX=/app
+
+RUN ln -s /usr/lib/x86_64-linux-gnu/libdl.so.2 /usr/lib/x86_64-linux-gnu/libdl.so
+
+WORKDIR /app/x64
+RUN ln -s /usr/lib/x86_64-linux-gnu/liblept.so.5 /app/x64/libleptonica-1.82.0.so \
+ && ln -s /usr/lib/x86_64-linux-gnu/libtesseract.so.5 /app/x64/libtesseract50.so
+
+WORKDIR /app
+
+# ───────────────────────────────
+# BUILD STAGE (Debian-based SDK)
+# ───────────────────────────────
+FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim AS build
 WORKDIR /src
 
-# Copy project file and restore
 COPY ["Paperless.OcrWorker.csproj", "./"]
-RUN dotnet restore "Paperless.OcrWorker.csproj"
+RUN dotnet restore "./Paperless.OcrWorker.csproj"
 
-# Copy the rest and publish
 COPY . .
 RUN dotnet publish "Paperless.OcrWorker.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
+# ───────────────────────────────
+# FINAL STAGE
+# ───────────────────────────────
 FROM base AS final
 WORKDIR /app
 COPY --from=build /app/publish .


### PR DESCRIPTION
…ries suitable for linux

For testing
after docker compose down and docker compose up -d --build:

docker compose exec paperless-ocrworker sh -c "ls -l /app/x64 && ls -l /usr/lib/x86_64-linux-gnu | grep -E 'tesseract|lept'"

this checks if the libraries for tesseract are installed. Keep in mind, that exactly like in the demo in Moodle, we dont install the tesseract CLI, but its libraries. And we make sure to install the .so files, to circumvent the issue of accidentally installing the dll files. Using the libraries, the container can still run tesseract through the .NET wrapper

The above command should show you something like this:

/app/x64/libleptonica-1.82.0.so -> /usr/lib/x86_64-linux-gnu/liblept.so.5
/app/x64/libtesseract50.so      -> /usr/lib/x86_64-linux-gnu/libtesseract.so.5
/usr/lib/x86_64-linux-gnu/libtesseract.so.5
/usr/lib/x86_64-linux-gnu/liblept.so.5


Also check Ghostscript:
docker compose exec paperless-ocrworker sh -c "which gs && gs --version"

see if a version gets shown.
