### PR TITLE
84 - added elastic search health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,12 @@ services:
     networks:
       - paperless-network
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS 'http://127.0.0.1:9200/_cluster/health?wait_for_status=yellow&timeout=1s' >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 18
+      start_period: 40s
 
   paperless-kibana:
     image: kibana:9.2.2
@@ -96,7 +102,8 @@ services:
     environment:
       - ELASTICSEARCH_URL=http://localhost:9200
     depends_on:
-      - paperless-elastic
+      paperless-elastic:
+        condition: service_healthy
     networks:
       - paperless-network
     restart: unless-stopped
@@ -127,10 +134,15 @@ services:
       - RABBITMQ_RESULTSQUEUE=${RABBITMQ_RESULTSQUEUE}
       - MINIO_ROOT_PASSWORD_FILE=/run/secrets/minio_password
     depends_on:
-      - paperless-postgres
-      - paperless-rabbitmq
-      - paperless-minio
-      - paperless-elastic
+      paperless-postgres:
+        condition: service_started
+      paperless-rabbitmq:
+        condition: service_started
+      paperless-minio:
+        condition: service_started
+      paperless-elastic:
+        condition: service_healthy
+
     secrets:
       - postgres_password
       - minio_password
@@ -152,10 +164,14 @@ services:
       - MINIO_ROOT_PASSWORD_FILE=/run/secrets/minio_password
       - GEMINI_BASE_URL=http://paperless-geminisummarizer:8090
     depends_on:
-      - paperless-rabbitmq
-      - paperless-minio
-      - paperless-geminisummarizer
-      - paperless-elastic
+      paperless-rabbitmq:
+        condition: service_started
+      paperless-minio:
+        condition: service_started
+      paperless-geminisummarizer:
+        condition: service_started
+      paperless-elastic:
+        condition: service_healthy
     secrets:
       - minio_password
     networks:


### PR DESCRIPTION
health check for elastic search. Only there specifically necessary because elastic search has a sort of false start: accepts tcp before ready, thats why needs health check to see if ready before it can be used.

Closes #84 